### PR TITLE
Add edge case coverage for root group users

### DIFF
--- a/files/create-sftp-user
+++ b/files/create-sftp-user
@@ -66,9 +66,12 @@ if [ -n "$gid" ]; then
 fi
 
 useradd "${useraddOptions[@]}" "$user"
-mkdir -p "/home/$user"
-chown root:root "/home/$user"
-chmod 755 "/home/$user"
+# Do not create home directories for admin accounts
+if [ "$gid" -ne 0 ]; then
+    mkdir -p "/home/$user"
+    chown root:root "/home/$user"
+    chmod 755 "/home/$user"
+fi
 
 # Retrieving user id to use it in chown commands instead of the user name
 # to avoid problems on alpine when the user name contains a '.'

--- a/files/create-sftp-user
+++ b/files/create-sftp-user
@@ -93,7 +93,6 @@ fi
 if [ -n "$dir" ]; then
     IFS=',' read -ra dirArgs <<< "$dir"
     for dirPath in "${dirArgs[@]}"; do
-        dirPath="/home/$user/$dirPath"
         if [ ! -d "$dirPath" ]; then
             log "Creating directory: $dirPath"
             mkdir -p "$dirPath"

--- a/files/create-sftp-user
+++ b/files/create-sftp-user
@@ -66,12 +66,9 @@ if [ -n "$gid" ]; then
 fi
 
 useradd "${useraddOptions[@]}" "$user"
-# Do not create home directories for admin accounts
-if [ "$gid" -ne 0 ]; then
-    mkdir -p "/home/$user"
-    chown root:root "/home/$user"
-    chmod 755 "/home/$user"
-fi
+mkdir -p "/home/$user"
+chown root:root "/home/$user"
+chmod 755 "/home/$user"
 
 # Retrieving user id to use it in chown commands instead of the user name
 # to avoid problems on alpine when the user name contains a '.'

--- a/files/create-sftp-user
+++ b/files/create-sftp-user
@@ -93,6 +93,7 @@ fi
 if [ -n "$dir" ]; then
     IFS=',' read -ra dirArgs <<< "$dir"
     for dirPath in "${dirArgs[@]}"; do
+        dirPath="$dirPath"
         if [ ! -d "$dirPath" ]; then
             log "Creating directory: $dirPath"
             mkdir -p "$dirPath"
@@ -101,4 +102,10 @@ if [ -n "$dir" ]; then
             log "Directory already exists: $dirPath"
         fi
     done
+fi
+
+# If user has root group access, let its home directory be /home so 
+# it may access other user's home directories.
+if [ "$gid" -eq 0 ]; then
+    usermod -d /home "$user"
 fi


### PR DESCRIPTION
Users with group ID of 0 will have their home directory changed to /home so that they may access all other user's home directories in their SFTP client.